### PR TITLE
Generate manual title page from meta data (again)

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -12,7 +12,7 @@
 
 SetPackageInfo( rec(
 PackageName := "CoReLG",
-Subtitle := "Computation with real Lie groups",
+Subtitle := "Computing with real Lie Algebras",
 Version := "1.51",
 Date := "15/07/2019", # this is in dd/mm/yyyy format
 License := "GPL-2.0-or-later",
@@ -26,6 +26,11 @@ IsAuthor := true,
 IsMaintainer := true,
 Email := "heiko.dietrich@monash.edu",
 WWWHome := "http://users.monash.edu.au/~heikod/",
+PostalAddress :=
+"""School of Mathematics
+Monash University
+Wellington Road 1
+VIC 3800, Melbourne, Australia""",
 Place := "Melbourne",
 Institution := "School of Mathematical Sciences, Monash University"
 ),
@@ -35,18 +40,28 @@ LastName := "Faccin",
 FirstNames := "Paolo",
 IsAuthor := true,
 IsMaintainer := true,
-Email := "faccin@science.unitn.it",
+Email := "paolofaccin86@gmail.com",
+PostalAddress :=
+"""Dipartimento di Matematica
+Via Sommarive 14
+I-38050 Povo (Trento), Italy
+""",
 Place := "Trento",
 Institution := "Dipartimento di Matematica, University of Trento"
 ),
 
 rec(
 LastName := "de Graaf",
-FirstNames := "Willem Adriaan",
+FirstNames := "Willem",
 IsAuthor := true,
 IsMaintainer := true,
 Email := "degraaf@science.unitn.it",
 WWWHome := "http://www.science.unitn.it/~degraaf",
+PostalAddress :=
+"""Dipartimento di Matematica
+Via Sommarive 14
+I-38050 Povo (Trento), Italy
+""",
 Place := "Trento",
 Institution := "Dipartimento di Matematica, University of Trento"
 )
@@ -74,7 +89,7 @@ ArchiveURLSubset := ["doc"],
 HTMLStart := "doc/chap0.html",
 PDFFile := "doc/manual.pdf",
 SixFile := "doc/manual.six",
-LongTitle := "Computing with real Lie groups",
+LongTitle := "Computing with real Lie Algebras",
 Autoload := false
 ),
 
@@ -91,7 +106,7 @@ AvailabilityTest := ReturnTrue,
 Autoload := false,
 
 # the banner
-BannerString := "CoReLG\n a package for computing with real Lie groups \n by Heiko Dietrich, Paolo Faccin and Willem de Graaf\n",
+BannerString := "CoReLG\n a package for computing with real Lie algebras \n by Heiko Dietrich, Paolo Faccin and Willem de Graaf\n",
 Keywords := ["real Lie algebras","nilpotent orbits Cartan subalgebras"],
 
 AutoDoc := rec(
@@ -104,9 +119,10 @@ aspects of the theory of real simple Lie algebras.
 Acknowledgements := """
 The research leading to this package has received funding from
 the European Union's Seventh Framework Program FP7/2007-2013
-under grant agreement no 271712.
+under grant agreement no 271712, and from the Australian Research
+Council, grantor code DE140100088 and DP190100317.
 """,
-Copyright := "&copyright; 2014 Heiko Dietrich, Paolo Faccin, and Willem de Graaf",
+Copyright := "&copyright; 2013-2019 Heiko Dietrich, Paolo Faccin, and Willem de Graaf",
 ),
 ),
 

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 
 <!DOCTYPE Book SYSTEM "gapdoc.dtd"
@@ -9,61 +9,7 @@
 
 <Book Name="CoReLG">
 
-<TitlePage>
-  <Title>CoReLG</Title>
-  <Subtitle>Computing with real Lie Algebras</Subtitle>
-  <Version>Version 1.51</Version>
-
-<Author>
-  Heiko Dietrich
-  <Email>heiko.dietrich@monash.edu</Email>
-  <Homepage>http://users.monash.edu.au/~heikod/</Homepage><Address>
- School of Mathematics<Br/>
- Monash University<Br/>
-Wellington Road 1<Br/>
-VIC 3800, Melbourne, Australia<Br/>
-       </Address> 
-  </Author>
-<Author>
- Paolo Faccin
-  <Email>paolofaccin86@gmail.com</Email>
-<Address>
-    	    Dipartimento di Matematica<Br/>
-Via Sommarive 14<Br/>
-I-38050 Povo (Trento), Italy<Br/>
-       </Address> 
-  </Author>
-<Author>
- Willem de Graaf  
-<Email>degraaf@science.unitn.it</Email>
-  <Homepage>http://www.science.unitn.it/~degraaf/</Homepage>
-          <Address>
-    	    Dipartimento di Matematica<Br/>
-Via Sommarive 14<Br/>
-I-38050 Povo (Trento), Italy<Br/>
-       </Address> 
-  </Author>
-
-  <Date>July 2019
-</Date>
-
-
-
-<Abstract>
-This package provides functions for computing with various aspects of
-the theory of real simple Lie algebras.
-</Abstract>
-
-<Acknowledgements>
-The research leading to this package has received funding from the European Union's Seventh Framework Program FP7/2007-2013 under grant agreement no 271712, and from the Australian Research Council, grantor code  DE140100088 and DP190100317
-</Acknowledgements>
-
-<Copyright>
-  &copyright; 2019 Heiko Dietrich, Paolo Faccin, and Willem de Graaf 
-</Copyright>
-  
-
-</TitlePage>
+<#Include SYSTEM "title.xml">
 
 <TableOfContents/>
 


### PR DESCRIPTION
For some reason, the title page that was being generated from the metadata in `PackageInfo.g` was again replaced by a hand written one in commit fd5b40f58b50b0c637640ea688b14e5069fdcd25 ? Not sure if this was intentional, but it immediately led to the usual problem of a release where updating the manual was initially forgotten (see commit a3ae465b4a3d348201f9f307874293a57aaee9ea).

This PR once again changes the title page to be generated from metadata; it also updates the metadata to ensure the generated title page matches the manually created one exactly (up to some minor bits: corrected copyright years; added a missing period; and the generated page has the full release date, not just month + year).

It also (partially?) addresses issue #1, which was necessary to get the subtitle on the title page right.

With this in place, during the next release, it will be sufficient to change `PackageInfo.g`, the version in the manual will be automatically right, as will be the release date, and any other metadata that is in the `PackageInfo.g` (such as author email addresses -- the one for Paolo Faccin differed between `PackageInfo.g` and the manual title page; I chose the latter, as I assume it is the correct one).