### PR TITLE
Avoid using DeclareGlobalVariable/InstallValue

### DIFF
--- a/gap/sqrt.gd
+++ b/gap/sqrt.gd
@@ -21,9 +21,8 @@ SqrtFieldType    := NewType( fam_SqrtFieldElt,
 ################################
 # SQRTFIELD
 DeclareCategory( "IsSqrtField", IsField );
-DeclareGlobalVariable( "SqrtField", "SqrtField..." );
 
-InstallValue( SqrtField,  Objectify( NewType( 
+BindGlobal( "SqrtField",  Objectify( NewType( 
                  CollectionsFamily( fam_SqrtFieldElt ),
                  IsField and
                  IsAttributeStoringRep and 


### PR DESCRIPTION
The main (only?) reason to use this combination is one needs to read in code
which references the variable before one can possible define the variable.
That's is not the case here.

On the GAP side, there are various issues with `InstallValue`, so on the long
run, some of us are thinking about replacing it with a better mechanism. While
it is not yet clear whether this will happen at all, and in which form,
avoiding its use in corelg means one place less we (the GAP team) have to
worry about it :-)